### PR TITLE
#36 - add keytype restriction to encryption methods + use key_select form element.

### DIFF
--- a/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
+++ b/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Contains \Drupal\encrypt_seclib\Plugin\EncryptionMethod\PHPSecLibEncryption.
+ */
+
 namespace Drupal\encrypt_seclib\Plugin\EncryptionMethod;
 
 use Drupal\encrypt\EncryptionMethodInterface;
@@ -13,13 +18,14 @@ use phpseclib\Crypt\AES;
  * @EncryptionMethod(
  *   id = "phpseclib",
  *   title = @Translation("PHP Secure Communications Library (phpseclib)"),
- *   description = "Uses the <a href='http://phpseclib.sourceforge.net/'>phpseclib</a> library. This method is only preferable if you cannot install mcrypt."
+ *   description = "Uses the <a href='http://phpseclib.sourceforge.net/'>phpseclib</a> library. This method is only preferable if you cannot install mcrypt.",
+ *   key_types = {"aes_encryption"}
  * )
  */
 class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterface {
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function encrypt($text, $key, $options = array()) {
     $processed_text = '';
@@ -40,7 +46,7 @@ class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterfac
   }
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function decrypt($text, $key, $options = array()) {
     $processed_text = '';
@@ -60,7 +66,7 @@ class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterfac
   }
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function checkDependencies($text = NULL, $key = NULL) {
     $errors = [];
@@ -70,4 +76,5 @@ class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterfac
     }
     return $errors;
   }
+
 }

--- a/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
+++ b/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
@@ -12,7 +12,8 @@ use Drupal\Core\Plugin\PluginBase;
 use phpseclib\Crypt\AES;
 
 /**
- * Class PHPSecLibEncryption
+ * Class PHPSecLibEncryption.
+ *
  * @package Drupal\encrypt_seclib\Plugin\EncryptionMethod
  *
  * @EncryptionMethod(
@@ -35,7 +36,6 @@ class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterfac
     $aes = new AES();
     $aes->setKey($key);
     $processed_text = $aes->encrypt($text);
-
 
     // If base64 encoding is not disabled.
     if (!$disable_base64) {

--- a/src/Annotation/EncryptionMethod.php
+++ b/src/Annotation/EncryptionMethod.php
@@ -41,4 +41,17 @@ class EncryptionMethod extends Plugin {
    * @var \Drupal\Core\Annotation\Translation
    */
   public $description = '';
+
+  /**
+   * Define key types this encryption method should be restricted to.
+   *
+   * Return an array of KeyType plugin IDs that restrict the allowed key types
+   * for usage with this encryption method.
+   *
+   * The KeyType plugin IDs should refer to valid subclasses of
+   * \Drupal\key\Plugin\KeyTypeBase.
+   * For example "aes_encryption" or "authentication" as provided by the Key
+   * module.
+   */
+  public $key_types = [];
 }

--- a/src/Annotation/EncryptionMethod.php
+++ b/src/Annotation/EncryptionMethod.php
@@ -54,4 +54,5 @@ class EncryptionMethod extends Plugin {
    * module.
    */
   public $key_types = [];
+
 }

--- a/src/EncryptionMethodInterface.php
+++ b/src/EncryptionMethodInterface.php
@@ -1,27 +1,42 @@
 <?php
 
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptionMethodInterface.
+ */
+
 namespace Drupal\encrypt;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
 
 /**
  * Interface EncryptionMethodInterface
+ *
  * @package Drupal\encrypt
  */
 interface EncryptionMethodInterface extends PluginInspectionInterface {
 
-    /**
-     * @return mixed
-     */
-    public function encrypt($text, $key);
+  /**
+   * Encrypt text with the given key.
+   *
+   * @return mixed
+   */
+  public function encrypt($text, $key);
 
-    /**
-     * @return mixed
-     */
-    public function decrypt($text, $key);
+  /**
+   * Decrypt text with the given key.
+   *
+   * @return mixed
+   */
+  public function decrypt($text, $key);
 
-    /**
-     * @return mixed
-     */
-    public function checkDependencies($text = NULL, $key = NULL);
+  /**
+   * Enforce dependencies for this encryption method.
+   *
+   * Return an array of error messages in case one or more dependencies
+   * are not met. Return an empty array if everything is OK.
+   *
+   * @return array
+   */
+  public function checkDependencies($text = NULL, $key = NULL);
 }

--- a/src/EncryptionMethodInterface.php
+++ b/src/EncryptionMethodInterface.php
@@ -10,7 +10,7 @@ namespace Drupal\encrypt;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 
 /**
- * Interface EncryptionMethodInterface
+ * Interface EncryptionMethodInterface.
  *
  * @package Drupal\encrypt
  */
@@ -20,6 +20,7 @@ interface EncryptionMethodInterface extends PluginInspectionInterface {
    * Encrypt text with the given key.
    *
    * @return mixed
+   *   The encrypted text.
    */
   public function encrypt($text, $key);
 
@@ -27,16 +28,16 @@ interface EncryptionMethodInterface extends PluginInspectionInterface {
    * Decrypt text with the given key.
    *
    * @return mixed
+   *   The decrypted text.
    */
   public function decrypt($text, $key);
 
   /**
    * Enforce dependencies for this encryption method.
    *
-   * Return an array of error messages in case one or more dependencies
-   * are not met. Return an empty array if everything is OK.
-   *
    * @return array
+   *   An array of error messages.
    */
   public function checkDependencies($text = NULL, $key = NULL);
+
 }

--- a/src/Form/EncryptionProfileForm.php
+++ b/src/Form/EncryptionProfileForm.php
@@ -21,16 +21,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EncryptionProfileForm extends EntityForm {
 
   /**
+   * A configuration factory.
+   *
    * @var \Drupal\Core\Config\ConfigFactory
    */
-  protected $config_factory;
+  protected $configFactory;
 
   /**
    * EncryptService definition.
    *
    * @var \Drupal\encrypt\EncryptService
    */
-  protected $encrypt_service;
+  protected $encryptService;
 
   /**
    * Constructs a EncryptionProfileForm object.
@@ -41,8 +43,8 @@ class EncryptionProfileForm extends EntityForm {
    *   The encrypt service.
    */
   public function __construct(ConfigFactoryInterface $config_factory, EncryptService $encrypt_service) {
-    $this->config_factory = $config_factory;
-    $this->encrypt_service = $encrypt_service;
+    $this->configFactory = $config_factory;
+    $this->encryptService = $encrypt_service;
   }
 
   /**
@@ -61,7 +63,7 @@ class EncryptionProfileForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
 
-    /** @var $encryption_profile \Drupal\encrypt\Entity\EncryptionProfile */
+    /* @var $encryption_profile \Drupal\encrypt\Entity\EncryptionProfile */
     $encryption_profile = $this->entity;
     $form['label'] = array(
       '#type' => 'textfield',
@@ -88,7 +90,7 @@ class EncryptionProfileForm extends EntityForm {
       '#suffix' => '</div>',
     );
 
-    $encryption_methods = $this->encrypt_service->loadEncryptionMethods();
+    $encryption_methods = $this->encryptService->loadEncryptionMethods();
     $method_options = [];
     $key_types = [];
     foreach ($encryption_methods as $plugin_id => $definition) {
@@ -129,7 +131,9 @@ class EncryptionProfileForm extends EntityForm {
    * AJAX callback to update the dynamic settings on the form.
    *
    * @param array $form
+   *   The form array.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The FormState object.
    *
    * @return array
    *   The element to update in the form.

--- a/src/Form/EncryptionProfileForm.php
+++ b/src/Form/EncryptionProfileForm.php
@@ -11,7 +11,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\encrypt\EncryptService;
-use Drupal\key\KeyRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -27,13 +26,6 @@ class EncryptionProfileForm extends EntityForm {
   protected $config_factory;
 
   /**
-   * KeyRepository definition.
-   *
-   * @var \Drupal\key\KeyRepository
-   */
-  protected $key_repository;
-
-  /**
    * EncryptService definition.
    *
    * @var \Drupal\encrypt\EncryptService
@@ -45,14 +37,11 @@ class EncryptionProfileForm extends EntityForm {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
-   * @param \Drupal\Key\KeyRepository $key_repository
-   *   The ConditionManager for building the visibility UI.
    * @param \Drupal\Encrypt\EncryptService $encrypt_service
-   *   The lazy context repository service.
+   *   The encrypt service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, KeyRepository $key_repository, EncryptService $encrypt_service) {
+  public function __construct(ConfigFactoryInterface $config_factory, EncryptService $encrypt_service) {
     $this->config_factory = $config_factory;
-    $this->key_repository = $key_repository;
     $this->encrypt_service = $encrypt_service;
   }
 
@@ -62,7 +51,6 @@ class EncryptionProfileForm extends EntityForm {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('key.repository'),
       $container->get('encryption')
     );
   }
@@ -72,12 +60,6 @@ class EncryptionProfileForm extends EntityForm {
    */
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
-
-    $keys = $this->key_repository->getKeys();
-
-    if (empty($keys)) {
-      drupal_set_message('No system keys (admin/config/system/key) are installed to manage encryption profiles.');
-    }
 
     /** @var $encryption_profile \Drupal\encrypt\Entity\EncryptionProfile */
     $encryption_profile = $this->entity;
@@ -99,39 +81,61 @@ class EncryptionProfileForm extends EntityForm {
       '#disabled' => !$encryption_profile->isNew(),
     );
 
-    /** @var $key \Drupal\key\Entity\KeyInterface */
-    foreach ($keys as $key) {
-      $key_id = $key->id();
-      $key_title = $key->label();
-      $keys[$key_id] = (string) $key_title;
-    }
-
-    if ($profile_key = $encryption_profile->getEncryptionKey()) {
-      $default_key = $profile_key;
-    }
-
-    $form['encryption_key'] = array(
-      '#type' => 'select',
-      '#title' => $this->t('Encryption Key'),
-      '#description' => $this->t('Select the key used for encryption.'),
-      '#options' => $keys,
-      '#default_value' => (empty($default_key)?NULL:$default_key),
-      '#required' => TRUE
+    // This is the element that contains all of the dynamic parts of the form.
+    $form['encryption'] = array(
+      '#type' => 'container',
+      '#prefix' => '<div id="encrypt-settings">',
+      '#suffix' => '</div>',
     );
 
-    $enc_methods = [];
-    foreach ($this->encrypt_service->loadEncryptionMethods() as $plugin_id => $definition) {
-      $enc_methods[$plugin_id] = (string) $definition['title'];
+    $encryption_methods = $this->encrypt_service->loadEncryptionMethods();
+    $method_options = [];
+    $key_types = [];
+    foreach ($encryption_methods as $plugin_id => $definition) {
+      $method_options[$plugin_id] = (string) $definition['title'];
+      $key_types[$plugin_id] = $definition['key_types'];
     }
-    $form['encryption_method'] = array(
+
+    $form['encryption']['encryption_method'] = array(
       '#type' => 'select',
       '#title' => $this->t('Encryption Method'),
       '#description' => $this->t('Select the method used for encryption'),
-      '#options' => $enc_methods,
+      '#options' => $method_options,
       '#default_value' => $encryption_profile->getEncryptionMethod(),
+      '#ajax' => array(
+        'callback' => [$this, 'ajaxUpdateSettings'],
+        'event' => 'change',
+        'wrapper' => 'encrypt-settings',
+      ),
+    );
+
+    $current_encryption_method = $encryption_profile->getEncryptionMethod();
+    if (!$current_encryption_method && !empty($encryption_methods)) {
+      // Get the first one from the list.
+      $current_encryption_method = array_shift(array_keys($encryption_methods));
+    }
+
+    $form['encryption']['encryption_key'] = array(
+      '#type' => 'key_select',
+      '#title' => $this->t('Encryption Key'),
+      '#required' => TRUE,
+      '#key_filters' => ['type' => $key_types[$current_encryption_method]],
     );
 
     return $form;
+  }
+
+  /**
+   * AJAX callback to update the dynamic settings on the form.
+   *
+   * @param array $form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *
+   * @return array
+   *   The element to update in the form.
+   */
+  public function ajaxUpdateSettings(array &$form, FormStateInterface $form_state) {
+    return $form['encryption'];
   }
 
   /**

--- a/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
+++ b/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Contains \Drupal\encrypt\Plugin\EncryptionMethod\McryptAES256Encryption.
+ */
+
 namespace Drupal\encrypt\Plugin\EncryptionMethod;
 
 use Drupal\encrypt\EncryptionMethodInterface;
@@ -12,13 +17,14 @@ use Drupal\Core\Plugin\PluginBase;
  * @EncryptionMethod(
  *   id = "mcrypt_aes_256",
  *   title = @Translation("Mcrypt AES 256"),
- *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-256</a>."
+ *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-256</a>.",
+ *   key_types = {"aes_encryption"}
  * )
  */
 class McryptAES256Encryption extends PluginBase implements EncryptionMethodInterface {
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function checkDependencies($text = NULL, $key = NULL) {
     $errors = array();
@@ -35,7 +41,7 @@ class McryptAES256Encryption extends PluginBase implements EncryptionMethodInter
   }
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function encrypt($text, $key, $options = array()) {
     $processed_text = '';
@@ -59,7 +65,7 @@ class McryptAES256Encryption extends PluginBase implements EncryptionMethodInter
   }
 
   /**
-   * @return mixed
+   * {@inheritdoc}
    */
   public function decrypt($text, $key, $options = array()) {
     $processed_text = '';
@@ -80,4 +86,5 @@ class McryptAES256Encryption extends PluginBase implements EncryptionMethodInter
     // Decrypt text.
     return trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $key, $text, MCRYPT_MODE_ECB, $iv));
   }
+
 }

--- a/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
+++ b/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
@@ -11,7 +11,8 @@ use Drupal\encrypt\EncryptionMethodInterface;
 use Drupal\Core\Plugin\PluginBase;
 
 /**
- * Class McryptAES256Encryption
+ * Class McryptAES256Encryption.
+ *
  * @package Drupal\encrypt\Plugin\EncryptionMethod
  *
  * @EncryptionMethod(
@@ -56,7 +57,7 @@ class McryptAES256Encryption extends PluginBase implements EncryptionMethodInter
 
     $processed_text = mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $key, $text, MCRYPT_MODE_ECB, $iv);
 
-    // Check if we are disabling base64 encoding
+    // Check if we are disabling base64 encoding.
     if (!$disable_base64) {
       $processed_text = base64_encode($processed_text);
     }
@@ -78,7 +79,7 @@ class McryptAES256Encryption extends PluginBase implements EncryptionMethodInter
     $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
     $disable_base64 = array_key_exists('base64', $options) && $options['base64'] == FALSE;
 
-    // Check if we are disabling base64 encoding
+    // Check if we are disabling base64 encoding.
     if (!$disable_base64) {
       $text = base64_decode($text);
     }


### PR DESCRIPTION
Changes in this pull request:

- Add an annotation "key_types" to EncryptionMethod plugins. This allows each EncryptionMethod plugin to define which key types are appropriate (and secure enough) to be used by that particular EncryptionMethod. One or more key types should be defined in the annotation.

- Update the EncryptionProfileForm to use they "key_select" form element from the Key module. The available keys in the selectlist are automatically filtered according to the "key_types" setting of the selected EncryptionMethod.

- Updates to match Drupal coding styles on the files that were touched by this pull request.