### PR TITLE
#73 - Allow encryption method to define support for key type and key …

### DIFF
--- a/encrypt.links.menu.yml
+++ b/encrypt.links.menu.yml
@@ -1,7 +1,5 @@
-# Title menu items definition
 entity.encryption_profile.collection:
-  title: 'Encryption Profile'
+  title: 'Encryption profiles'
   route_name: entity.encryption_profile.collection
-  description: 'Encryption Profile listing'
+  description: 'Manage profiles that can be used to encrypt and decrypt data.'
   parent: system.admin_config_system
-

--- a/encrypt.routing.yml
+++ b/encrypt.routing.yml
@@ -1,32 +1,31 @@
-# Encryption Profile routing definition
 entity.encryption_profile.collection:
-  path: '/admin/config/system/encryption'
+  path: '/admin/config/system/encryption/profiles'
   defaults:
     _entity_list: 'encryption_profile'
-    _title: 'Encryption Profiles'
+    _title: 'Encryption profiles'
   requirements:
     _permission: 'administer encrypt'
 
 entity.encryption_profile.add_form:
-  path: '/admin/config/system/encryption/profile/add'
+  path: '/admin/config/system/encryption/profiles/add'
   defaults:
     _entity_form: 'encryption_profile.add'
-    _title: 'Add Encryption Profile'
+    _title: 'Add encryption profile'
   requirements:
     _permission: 'administer encrypt'
 
 entity.encryption_profile.edit_form:
-  path: '/admin/config/system/encryption/profile/{encryption_profile}'
+  path: '/admin/config/system/encryption/profiles/manage/{encryption_profile}'
   defaults:
     _entity_form: 'encryption_profile.edit'
-    _title: 'Edit Encryption Profile'
+    _title: 'Edit encryption profile'
   requirements:
     _permission: 'administer encrypt'
 
 entity.encryption_profile.delete_form:
-  path: '/admin/config/system/encryption/profile/{encryption_profile}/delete'
+  path: '/admin/config/system/encryption/profiles/manage/{encryption_profile}/delete'
   defaults:
     _entity_form: 'encryption_profile.delete'
-    _title: 'Delete Encryption Profile'
+    _title: 'Delete encryption profile'
   requirements:
     _permission: 'administer encrypt'

--- a/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
+++ b/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
@@ -14,8 +14,8 @@ use phpseclib\Crypt\AES;
  *   id = "phpseclib",
  *   title = @Translation("PHP Secure Communications Library (phpseclib)"),
  *   description = "Uses the <a href='http://phpseclib.sourceforge.net/'>phpseclib</a> library. This method is only preferable if you cannot install mcrypt.",
- *   key_type = "aes_encryption",
- *   key_sizes = {"128_bits", "192_bits", "256_bits"}
+ *   key_type = {"aes_encryption"},
+ *   key_size = {"128", "192", "256"}
  * )
  */
 class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterface {

--- a/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
+++ b/modules/encrypt_seclib/src/Plugin/EncryptionMethod/PHPSecLibEncryption.php
@@ -13,7 +13,9 @@ use phpseclib\Crypt\AES;
  * @EncryptionMethod(
  *   id = "phpseclib",
  *   title = @Translation("PHP Secure Communications Library (phpseclib)"),
- *   description = "Uses the <a href='http://phpseclib.sourceforge.net/'>phpseclib</a> library. This method is only preferable if you cannot install mcrypt."
+ *   description = "Uses the <a href='http://phpseclib.sourceforge.net/'>phpseclib</a> library. This method is only preferable if you cannot install mcrypt.",
+ *   key_type = "aes_encryption",
+ *   key_sizes = {"128_bits", "192_bits", "256_bits"}
  * )
  */
 class PHPSecLibEncryption extends PluginBase implements EncryptionMethodInterface {

--- a/modules/encrypt_seclib/src/Tests/EncryptService.php
+++ b/modules/encrypt_seclib/src/Tests/EncryptService.php
@@ -51,7 +51,7 @@ class EncryptService extends WebTestBase {
       'encryption_key' => 'testing_key',
       'encryption_method' => 'phpseclib',
     ];
-    $this->drupalPostForm('admin/config/system/encryption/profile/add', $edit, t('Save'));
+    $this->drupalPostForm('admin/config/system/encryption/profiles/add', $edit, t('Save'));
 
 
     // Test encryption service.

--- a/src/Annotation/EncryptionMethod.php
+++ b/src/Annotation/EncryptionMethod.php
@@ -44,7 +44,7 @@ class EncryptionMethod extends Plugin {
 
 
   /**
-   * The key type this encryption method should use.
+   * The key type(s) this encryption method should use.
    *
    * If none specified, all keys within the group "encryption" will be
    * available to this encryption method.
@@ -52,9 +52,9 @@ class EncryptionMethod extends Plugin {
    * This setting should refer to a valid Plugin ID of type KeyType.
    * For example "aes_encryption", provided by the Key module.
    *
-   * @var string
+   * @var array
    */
-  public $key_type = '';
+  public $key_type = [];
 
   /**
    * The key sizes allowed to be used with this encryption method.
@@ -65,6 +65,6 @@ class EncryptionMethod extends Plugin {
    *
    * @var array
    */
-  public $key_sizes = [];
+  public $key_size = [];
 
 }

--- a/src/Annotation/EncryptionMethod.php
+++ b/src/Annotation/EncryptionMethod.php
@@ -59,7 +59,8 @@ class EncryptionMethod extends Plugin {
   /**
    * The key sizes allowed to be used with this encryption method.
    *
-   * Example values: "128_bits", "192_bits", "256_bits"
+   * Values can be numeric value, or a range.
+   * Examples: {"128", "192", "256"} or {"32-448"}
    *
    * @see \Drupal\key\KeyProvider\AesEncryptionKeyType
    *

--- a/src/Annotation/EncryptionMethod.php
+++ b/src/Annotation/EncryptionMethod.php
@@ -41,4 +41,30 @@ class EncryptionMethod extends Plugin {
    * @var \Drupal\Core\Annotation\Translation
    */
   public $description = '';
+
+
+  /**
+   * The key type this encryption method should use.
+   *
+   * If none specified, all keys within the group "encryption" will be
+   * available to this encryption method.
+   *
+   * This setting should refer to a valid Plugin ID of type KeyType.
+   * For example "aes_encryption", provided by the Key module.
+   *
+   * @var string
+   */
+  public $key_type = '';
+
+  /**
+   * The key sizes allowed to be used with this encryption method.
+   *
+   * Example values: "128_bits", "192_bits", "256_bits"
+   *
+   * @see \Drupal\key\KeyProvider\AesEncryptionKeyType
+   *
+   * @var array
+   */
+  public $key_sizes = [];
+
 }

--- a/src/EncryptionProfileInterface.php
+++ b/src/EncryptionProfileInterface.php
@@ -27,4 +27,12 @@ interface EncryptionProfileInterface extends ConfigEntityInterface {
    */
   public function getEncryptionKey();
 
+  /**
+   * Validate the EncryptionProfile entity.
+   *
+   * @return array
+   *   An array of validation errors. Empty if no errors.
+   */
+  public function validate();
+
 }

--- a/src/Entity/EncryptionProfile.php
+++ b/src/Entity/EncryptionProfile.php
@@ -35,11 +35,11 @@ use Drupal\encrypt\Exception\KeyNotAllowedException;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "canonical" = "/admin/config/system/encryption/profile/{encryption_profile}",
- *     "add-form" = "/admin/config/system/encryption/profile/add",
- *     "edit-form" = "/admin/config/system/encryption/profile/{encryption_profile}/edit",
- *     "delete-form" = "/admin/config/system/encryption/profile/{encryption_profile}/delete",
- *     "collection" = "/admin/config/system/encryption/profile",
+ *     "canonical" = "/admin/config/system/encryption/profiles/{encryption_profile}",
+ *     "add-form" = "/admin/config/system/encryption/profiles/add",
+ *     "edit-form" = "/admin/config/system/encryption/profiles/manage/{encryption_profile}",
+ *     "delete-form" = "/admin/config/system/encryption/profiles/manage/{encryption_profile}/delete",
+ *     "collection" = "/admin/config/system/encryption/profiles"
  *   }
  * )
  */

--- a/src/Entity/EncryptionProfile.php
+++ b/src/Entity/EncryptionProfile.php
@@ -8,7 +8,9 @@
 namespace Drupal\encrypt\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\encrypt\EncryptionProfileInterface;
+use Drupal\encrypt\Exception\KeyNotAllowedException;
 
 /**
  * Defines the Title entity.
@@ -84,4 +86,149 @@ class EncryptionProfile extends ConfigEntityBase implements EncryptionProfileInt
     return $this->encryption_key;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+    $errors = $this->validate();
+    if (!empty($errors)) {
+      throw new KeyNotAllowedException(implode(';', $errors));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate() {
+    $errors = [];
+    $allowed_keys = array_keys($this->getAllowedKeys());
+    if (empty($allowed_keys)) {
+      $errors[] = t('No valid keys found for the selected encryption method');
+    }
+    else {
+      if (!in_array($this->getEncryptionKey(), $allowed_keys)) {
+        $errors[] = t('The selected key cannot be used with the selected encryption method.');
+      }
+    }
+    return $errors;
+  }
+
+  /**
+   * Get a list of allowed keys for the given encryption method.
+   *
+   * @param string $encryption_method
+   *   The selected encryption method.
+   * @return array
+   *   A list of allowed keys.
+   */
+  public function getAllowedKeys($encryption_method = NULL) {
+    $allowed_keys = [];
+    if (!$encryption_method) {
+      $encryption_method = $this->getEncryptionMethod();
+    }
+    $encryption_method_definition = static::getEncryptionMethodManager()->getDefinition($encryption_method);
+
+    /** @var $key \Drupal\key\KeyInterface */
+    foreach ($this->getKeyRepository()->getKeys() as $key) {
+      $key_type = $key->getKeyType();
+      $key_type_definition = $this->getKeyManager()->getDefinition($key_type->getPluginId());
+
+      // @TODO: remove this check and only get Keys of type EncryptionKeyType or child classes.
+      // This still needs to be implemented in Key module first.
+      // Don't allow keys with key types other than encryption.
+      if ($key_type_definition['group'] != "encryption") {
+        continue;
+      }
+
+      // Don't allow keys with incorrect sizes.
+      if (isset($encryption_method_definition['key_size'])) {
+        $allowed_key_sizes = $encryption_method_definition['key_size'];
+        $key_type_config = $key_type->getConfiguration();
+        if (!isset($key_type_config['key_size']) || !$this->validKeySize($key_type_config['key_size'], $allowed_key_sizes)) {
+          continue;
+        }
+      }
+
+      // Don't allow keys with incorrect key_type, if defined in the encryption
+      // method definition.
+      if (isset($encryption_method_definition['key_type']) && !empty($encryption_method_definition['key_type'])) {
+        if (!in_array($key_type->getPluginId(), $encryption_method_definition['key_type'])) {
+          continue;
+        }
+      }
+
+      $key_id = $key->id();
+      $key_title = $key->label();
+      $allowed_keys[$key_id] = (string) $key_title;
+    }
+    return $allowed_keys;
+  }
+
+  /**
+   * Validates if key size matches the allowed values of the encryption method.
+   *
+   * @param mixed $key_size
+   *   The key size as defined by the Key type.
+   * @param array $allowed_key_sizes
+   *   The allowed key sizes as defined by the encryption method.
+   * @return bool
+   *   Whether or not the key size is valid.
+   */
+  protected function validKeySize($key_size, array $allowed_key_sizes) {
+    $valid = FALSE;
+    // Make sure we're dealing with an integer.
+    // Strips out optional "_bits" suffix from Key module.
+    $key_size = (int) $key_size;
+
+    if (!empty($allowed_key_sizes)) {
+      foreach ($allowed_key_sizes as $allowed) {
+        // Check if allowed key size is a range or not.
+        if (strpos($allowed, '-') !== FALSE) {
+          list($min, $max) = explode('-', $allowed, 2);
+          if (($min <= $key_size) && ($key_size <= $max)) {
+            $valid = TRUE;
+          }
+        }
+        else {
+          if ($allowed == $key_size) {
+            $valid = TRUE;
+          }
+        }
+      }
+    }
+
+    return $valid;
+  }
+
+
+  /**
+   * Gets the encryption method manager.
+   *
+   * @return \Drupal\encrypt\EncryptionMethodManager
+   *   The EncryptionMethodManager.
+   */
+  protected static function getEncryptionMethodManager() {
+    return \Drupal::service('plugin.manager.encrypt.encryption_methods');
+  }
+
+  /**
+   * Gets the key repository service.
+   *
+   * @return \Drupal\Key\KeyRepository
+   *   The Key repository service.
+   */
+  protected static function getKeyRepository() {
+    return \Drupal::service('key.repository');
+  }
+
+  /**
+   * Gets the key manager service.
+   *
+   * @return \Drupal\key\Plugin\KeyPluginManager
+   *   The Key manager service.
+   */
+  protected static function getKeyManager() {
+    return \Drupal::service('plugin.manager.key.key_type');
+  }
 }

--- a/src/Exception/KeyNotAllowedException.php
+++ b/src/Exception/KeyNotAllowedException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\Exception\KeyNotAllowedException.
+ */
+
+namespace Drupal\encrypt\Exception;
+
+/**
+ * Class KeyNotAllowedException.
+ */
+class KeyNotAllowedException extends \Exception {}

--- a/src/Form/EncryptionProfileForm.php
+++ b/src/Form/EncryptionProfileForm.php
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\encrypt\EncryptService;
 use Drupal\key\KeyRepository;
+use Drupal\key\Plugin\KeyPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -24,21 +25,28 @@ class EncryptionProfileForm extends EntityForm {
   /**
    * @var \Drupal\Core\Config\ConfigFactory
    */
-  protected $config_factory;
+  protected $configFactory;
 
   /**
-   * KeyRepository definition.
+   * The available keys.
    *
-   * @var \Drupal\key\KeyRepository
+   * @var \Drupal\key\KeyInterface[]
    */
-  protected $key_repository;
+  protected $keys;
 
   /**
-   * EncryptService definition.
+   * The available encryption methods.
    *
-   * @var \Drupal\encrypt\EncryptService
+   * @var \Drupal\encrypt\EncryptionMethodInterface[]
    */
-  protected $encrypt_service;
+  protected $encryptionMethods;
+
+  /**
+   * The Key plugin manager service.
+   *
+   * @var \Drupal\key\Plugin\KeyPluginManager
+   */
+  protected $keyManager;
 
   /**
    * Constructs a EncryptionProfileForm object.
@@ -48,12 +56,15 @@ class EncryptionProfileForm extends EntityForm {
    * @param \Drupal\Key\KeyRepository $key_repository
    *   The ConditionManager for building the visibility UI.
    * @param \Drupal\Encrypt\EncryptService $encrypt_service
-   *   The lazy context repository service.
+   *   The encrypt service.
+   * @param \Drupal\key\Plugin\KeyPluginManager $key_manager
+   *   The key manager service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, KeyRepository $key_repository, EncryptService $encrypt_service) {
-    $this->config_factory = $config_factory;
-    $this->key_repository = $key_repository;
-    $this->encrypt_service = $encrypt_service;
+  public function __construct(ConfigFactoryInterface $config_factory, KeyRepository $key_repository, EncryptService $encrypt_service, KeyPluginManager $key_manager) {
+    $this->configFactory = $config_factory;
+    $this->keys = $key_repository->getKeys();
+    $this->encryptionMethods = $encrypt_service->loadEncryptionMethods();
+    $this->keyManager = $key_manager;
   }
 
   /**
@@ -63,7 +74,8 @@ class EncryptionProfileForm extends EntityForm {
     return new static(
       $container->get('config.factory'),
       $container->get('key.repository'),
-      $container->get('encryption')
+      $container->get('encryption'),
+      $container->get('plugin.manager.key.key_type')
     );
   }
 
@@ -73,9 +85,7 @@ class EncryptionProfileForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
 
-    $keys = $this->key_repository->getKeys();
-
-    if (empty($keys)) {
+    if (empty($this->keys)) {
       drupal_set_message('No system keys (admin/config/system/key) are installed to manage encryption profiles.');
     }
 
@@ -99,39 +109,111 @@ class EncryptionProfileForm extends EntityForm {
       '#disabled' => !$encryption_profile->isNew(),
     );
 
-    /** @var $key \Drupal\key\Entity\KeyInterface */
-    foreach ($keys as $key) {
-      $key_id = $key->id();
-      $key_title = $key->label();
-      $keys[$key_id] = (string) $key_title;
+    // This is the element that contains all of the dynamic parts of the form.
+    $form['encryption'] = array(
+      '#type' => 'container',
+      '#prefix' => '<div id="encrypt-settings">',
+      '#suffix' => '</div>',
+    );
+
+    $encryption_methods = [];
+    foreach ($this->encryptionMethods as $plugin_id => $definition) {
+      $encryption_methods[$plugin_id] = (string) $definition['title'];
     }
 
+    $current_encryption_method = $encryption_profile->getEncryptionMethod();
+    if (!$current_encryption_method && !empty($encryption_methods)) {
+      // Get the first one from the list.
+      $current_encryption_method = array_shift(array_keys($encryption_methods));
+    }
+
+    $form['encryption']['encryption_method'] = array(
+      '#type' => 'select',
+      '#title' => $this->t('Encryption Method'),
+      '#description' => $this->t('Select the method used for encryption'),
+      '#options' => $encryption_methods,
+      '#default_value' => $current_encryption_method,
+      '#ajax' => array(
+        'callback' => [$this, 'ajaxUpdateSettings'],
+        'event' => 'change',
+        'wrapper' => 'encrypt-settings',
+      ),
+    );
+
+    $keys = $this->getAllowedKeys($current_encryption_method);
     if ($profile_key = $encryption_profile->getEncryptionKey()) {
       $default_key = $profile_key;
     }
 
-    $form['encryption_key'] = array(
+    $form['encryption']['encryption_key'] = array(
       '#type' => 'select',
       '#title' => $this->t('Encryption Key'),
-      '#description' => $this->t('Select the key used for encryption.'),
+      '#description' => $this->t('Select the key used for encryption. Only key types that are allowed for the selected encryption method are listed here.'),
       '#options' => $keys,
-      '#default_value' => (empty($default_key)?NULL:$default_key),
-      '#required' => TRUE
-    );
-
-    $enc_methods = [];
-    foreach ($this->encrypt_service->loadEncryptionMethods() as $plugin_id => $definition) {
-      $enc_methods[$plugin_id] = (string) $definition['title'];
-    }
-    $form['encryption_method'] = array(
-      '#type' => 'select',
-      '#title' => $this->t('Encryption Method'),
-      '#description' => $this->t('Select the method used for encryption'),
-      '#options' => $enc_methods,
-      '#default_value' => $encryption_profile->getEncryptionMethod(),
+      '#default_value' => empty($default_key) ? NULL : $default_key,
+      '#required' => TRUE,
     );
 
     return $form;
+  }
+
+  /**
+   * Get a list of allowed keys for the given encryption method.
+   *
+   * @param string $encryption_method
+   *   The selected encryption method.
+   * @return array
+   *   A list of allowed keys.
+   */
+  protected function getAllowedKeys($encryption_method) {
+    $allowed_keys = [];
+    $encryption_method_definition = $this->encryptionMethods[$encryption_method];
+
+    /** @var $key \Drupal\key\KeyInterface */
+    foreach ($this->keys as $key) {
+      $key_type = $key->getKeyType();
+      $key_type_definition = $this->keyManager->getDefinition($key_type->getPluginId());
+
+      // Don't allow keys with key types other than encryption.
+      if ($key_type_definition['group'] != "encryption") {
+        continue;
+      }
+
+      // Don't allow keys with incorrect sizes.
+      $allowed_key_sizes = $encryption_method_definition['key_sizes'];
+      $key_type_config = $key_type->getConfiguration();
+
+      if (!isset($key_type_config['key_size']) || !in_array($key_type_config['key_size'], $allowed_key_sizes)) {
+        continue;
+      }
+      // Don't allow keys with incorrect key_type, if defined in the encryption
+      // method definition.
+      if (isset($encryption_method_definition['key_type'])) {
+        if ($encryption_method_definition['key_type'] != $key_type->getPluginId()) {
+          continue;
+        }
+      }
+
+      $key_id = $key->id();
+      $key_title = $key->label();
+      $allowed_keys[$key_id] = (string) $key_title;
+    }
+    return $allowed_keys;
+  }
+
+  /**
+   * AJAX callback to update the dynamic settings on the form.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The FormState object.
+   *
+   * @return array
+   *   The element to update in the form.
+   */
+  public function ajaxUpdateSettings(array &$form, FormStateInterface $form_state) {
+    return $form['encryption'];
   }
 
   /**

--- a/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
+++ b/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
@@ -13,8 +13,8 @@ use Drupal\Core\Plugin\PluginBase;
  *   id = "mcrypt_aes_256",
  *   title = @Translation("Mcrypt AES 256"),
  *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-256</a>.",
- *   key_type = "aes_encryption",
- *   key_sizes = {"256_bits"}
+ *   key_type = {"aes_encryption"},
+ *   key_size = {"128", "192", "256"}
  * )
  */
 class McryptAES256Encryption extends PluginBase implements EncryptionMethodInterface {

--- a/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
+++ b/src/Plugin/EncryptionMethod/McryptAES256Encryption.php
@@ -12,7 +12,9 @@ use Drupal\Core\Plugin\PluginBase;
  * @EncryptionMethod(
  *   id = "mcrypt_aes_256",
  *   title = @Translation("Mcrypt AES 256"),
- *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-256</a>."
+ *   description = "This uses PHPs mcrypt extension and <a href='http://en.wikipedia.org/wiki/Advanced_Encryption_Standard'>AES-256</a>.",
+ *   key_type = "aes_encryption",
+ *   key_sizes = {"256_bits"}
  * )
  */
 class McryptAES256Encryption extends PluginBase implements EncryptionMethodInterface {

--- a/src/Tests/EncryptEncryptDecryptTest.php
+++ b/src/Tests/EncryptEncryptDecryptTest.php
@@ -38,7 +38,7 @@ class EncryptEncryptDecryptTest extends \Drupal\simpletest\WebTestBase {
     $this->drupalPostForm(NULL, $edit, t('Save'));
 
     // Setup an initial encryption profile and default it.
-    $this->drupalGet('admin/config/system/encryption/profile/add');
+    $this->drupalGet('admin/config/system/encryption/profiles/add');
     $edit = [
       'id' => 'testing_profile',
       'label' => 'Testing profile',

--- a/src/Tests/EncryptEncryptionMethodPluginsTest.php
+++ b/src/Tests/EncryptEncryptionMethodPluginsTest.php
@@ -32,7 +32,7 @@ class EncryptEncryptionMethodPluginsTest extends \Drupal\simpletest\WebTestBase 
    * The declared encryption method appears on the add configuration page.
    */
   public function testPluginsAppearInList() {
-    $this->drupalGet('admin/config/system/encryption/profile/add');
+    $this->drupalGet('admin/config/system/encryption/profiles/add');
     // Check if the plugin exists.
     $this->assertOption('edit-encryption-method', 'phpseclib', t('Encryption method option is present.'));
     $this->assertText('PHP Secure Communications Library (phpseclib)', t('Encryption method text is present'));

--- a/src/Tests/EncryptService.php
+++ b/src/Tests/EncryptService.php
@@ -50,7 +50,7 @@ class EncryptService extends WebTestBase {
       'encryption_key' => 'testing_key',
       'encryption_method' => 'mcrypt_aes_256',
     ];
-    $this->drupalPostForm('admin/config/system/encryption/profile/add', $edit, t('Save'));
+    $this->drupalPostForm('admin/config/system/encryption/profiles/add', $edit, t('Save'));
 
 
     // Test encryption service.

--- a/tests/drupal_ti/before/before_script.sh
+++ b/tests/drupal_ti/before/before_script.sh
@@ -19,8 +19,8 @@ cd "$DRUPAL_TI_DRUPAL_DIR"
 mkdir -p "$DRUPAL_TI_DRUPAL_DIR/$DRUPAL_TI_MODULES_PATH"
 cd "$DRUPAL_TI_DRUPAL_DIR/$DRUPAL_TI_MODULES_PATH"
 
-# Manually clone the dependencies
-git clone --depth 1 https://github.com/d8-contrib-modules/key.git
+# Download the dependencies
+drush dl key --dev -y
 
 # We need to perform the composer manager install for seclib submodule
 cd "$DRUPAL_TI_DRUPAL_DIR"


### PR DESCRIPTION
Here's a pull request based on the input from several Github issues:
https://github.com/d8-contrib-modules/encrypt/issues/73
https://github.com/d8-contrib-modules/encrypt/issues/71
https://github.com/d8-contrib-modules/encrypt/issues/36#issuecomment-180594285

It's a replacement for my earlier pull request: https://github.com/d8-contrib-modules/encrypt/pull/67

This adds 2 new annotations to EncryptionMethod plugins.
When creating an EncryptionProfile, only keys that are allowed by the selected encryption method, are available for selection.

Let me know if this is the direction we should go in. 