### PR TITLE
#75 - add information about status of profile

### DIFF
--- a/config/install/encrypt.settings.yml
+++ b/config/install/encrypt.settings.yml
@@ -1,0 +1,1 @@
+check_profile_status: true

--- a/config/schema/encrypt.schema.yml
+++ b/config/schema/encrypt.schema.yml
@@ -1,0 +1,7 @@
+encrypt.settings:
+  type: mapping
+  label: 'Encrypt Settings'
+  mapping:
+    check_profile_status:
+      type: boolean
+      label: 'Check profile validation status.'

--- a/encrypt.links.task.yml
+++ b/encrypt.links.task.yml
@@ -1,0 +1,9 @@
+encrypt.list_tab:
+  route_name: entity.encryption_profile.collection
+  title: List
+  base_route: entity.encryption_profile.collection
+
+encrypt.settings_tab:
+  route_name: encrypt.settings
+  title: Settings
+  base_route: entity.encryption_profile.collection

--- a/encrypt.routing.yml
+++ b/encrypt.routing.yml
@@ -29,3 +29,11 @@ entity.encryption_profile.delete_form:
     _title: 'Delete encryption profile'
   requirements:
     _permission: 'administer encrypt'
+
+encrypt.settings:
+  path: '/admin/config/system/encryption/profiles/settings'
+  defaults:
+    _form: '\Drupal\encrypt\Form\EncryptSettingsForm'
+    _title: 'Encrypt settings'
+  requirements:
+    _permission: 'administer encrypt'

--- a/src/Form/EncryptSettingsForm.php
+++ b/src/Form/EncryptSettingsForm.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\Form\EncryptSettingsForm.
+ */
+
+namespace Drupal\encrypt\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form builder for the encrypt settings admin page.
+ */
+class EncryptSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'encrypt_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['encrypt.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $config = $this->config('encrypt.settings');
+
+    $form['check_profile_status'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show the validation status of encryption profiles.'),
+      '#description' => $this->t('On the encryption profiles overview page, automatically validate each encryption profile to check if there are problems with it. Disable when you have a lot of encryption profiles and are encountering performance issues, or if you do not want encryption keys to be loaded by the status check.'),
+      '#default_value' => $config->get('check_profile_status'),
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('encrypt.settings')
+      ->set('check_profile_status', $form_state->getValue('check_profile_status'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
New PR added.

* Adds a configuration option to check statuses of available profiles.
* Adds a settings tab to enable / disable the status checking option (enabled by default)
* Status check calls the EncryptProfile validate() functionality that was introduced earlier
* That validate() function has now been expanded:
  * check if a valid encryptionmethod is set
  * check if a valid encryptionkey is set
  * check if the key type is allowed by the encryptionmethod
  * checks the encryptionmethods checkDependencies() method, passing in the current key value

Example: https://www.evernote.com/l/AAZDRTIsCoZAQJRyvIG41QPI07cVp2lpYDY

This can be tested by deleting a key or encryptionmethod that was used in an encryptionprofile, or changing the key value so the requirements are no longer met.