### PR TITLE
Simplify EncryptService

### DIFF
--- a/drush/encrypt.drush.inc
+++ b/drush/encrypt.drush.inc
@@ -6,6 +6,20 @@
  */
 
 use Drupal\encrypt\Entity\EncryptionProfile;
+use Drush\Log\Logger;
+use Drush\Log\LogLevel;
+
+/**
+ * Implementation of hook_drush_help().
+ */
+function encrypt_drush_help($section) {
+  switch ($section) {
+    case 'meta:encrypt:title':
+      return dt('Encrypt commands');
+    case 'meta:encrypt:summary':
+      return dt('Interact with the encryption service.');
+  }
+}
 
 /**
  * Implements hook_drush_command().
@@ -13,7 +27,7 @@ use Drupal\encrypt\Entity\EncryptionProfile;
 function encrypt_drush_command() {
   $items = array();
 
-  $items['encrypt'] = array(
+  $items['encrypt-encrypt'] = array(
     'description' => "Encrypt text with the provided encryption profile.",
     'arguments' => array(
       'profile' => 'The machine name of the encryption profile to use.',
@@ -22,13 +36,13 @@ function encrypt_drush_command() {
       'base64' => 'Output the encrypted text in base64 encoded format.',
     ),
     'examples' => array(
-      "drush encrypt profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile.',
-      "drush encrypt --base64 profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile and base64-encodes output.',
+      "drush encrypt-encrypt profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile.',
+      "drush encrypt-encrypt --base64 profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile and base64-encodes output.',
     ),
-    'callback' => 'drush_encrypt_encrypt',
+    'aliases' => array('encrypt', 'enc'),
   );
 
-  $items['decrypt'] = array(
+  $items['encrypt-decrypt'] = array(
     'description' => "Decrypt text with the provided encryption profile.",
     'arguments' => array(
       'profile' => 'The machine name of the encryption profile to use.',
@@ -37,10 +51,28 @@ function encrypt_drush_command() {
       'base64' => 'Output the encrypted text in base64 encoded format.',
     ),
     'examples' => array(
-      "drush decrypt profile_name 'text to decrypt'" => 'Decrypts the given text with the specified encryption profile.',
-      "drush decrypt --base64 profile_name 'text to decrypt'" => 'Decrypts the given base64-encoded text with the specified encryption profile.',
+      "drush encrypt-decrypt profile_name 'text to decrypt'" => 'Decrypts the given text with the specified encryption profile.',
+      "drush encrypt-decrypt --base64 profile_name 'text to decrypt'" => 'Decrypts the given base64-encoded text with the specified encryption profile.',
     ),
-    'callback' => 'drush_encrypt_decrypt',
+    'aliases' => array('decrypt', 'dec'),
+  );
+
+  $items['encrypt-validate-profile'] = array(
+    'description' => "Validates a provided encryption profile to check if all dependencies are met.",
+    'arguments' => array(
+      'profile' => 'The machine name of the encryption profile to validate.',
+    ),
+    'examples' => array(
+      "drush encrypt-validate-profile profile_name" => 'Validates the given encryption profile.',
+    ),
+    'aliases' => array('evp'),
+    'outputformat' => array(
+      'default' => 'table',
+      'pipe-format' => 'list',
+      'field-default' => array('error'),
+      'field-labels' => array('error' => 'Error messages:'),
+      'output-data-type' => 'format-table',
+    ),
   );
 
   return $items;
@@ -99,5 +131,35 @@ function drush_encrypt_decrypt($encryption_profile_name, $text) {
     }
     $decrypted_text = $service->decrypt($text, $encryption_profile);
     drush_print($decrypted_text);
+  }
+}
+
+/**
+ * Validates the given encryption profile.
+ *
+ * @param $encryption_profile_name
+ */
+function drush_encrypt_validate_profile($encryption_profile_name) {
+  $output = array();
+  $encryption_profile = EncryptionProfile::load($encryption_profile_name);
+  if (!$encryption_profile) {
+    return drush_set_error('', dt('Encryption profile "@name" could not be loaded.', array(
+      '@name' => $encryption_profile_name,
+    )));
+  }
+  else {
+    $errors = $encryption_profile->validate();
+    if ($errors) {
+      foreach ($errors as $error_msg) {
+        $row = array(
+          'error' => $error_msg,
+        );
+        $output[] = $row;
+      }
+      return $output;
+    }
+    else {
+      drush_log(dt('Encryption profile validates successfully.'), LogLevel::SUCCESS);
+    }
   }
 }

--- a/drush/encrypt.drush.inc
+++ b/drush/encrypt.drush.inc
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @file
+ * Drush integration for Encrypt module.
+ */
+
+use Drupal\encrypt\Entity\EncryptionProfile;
+
+/**
+ * Implements hook_drush_command().
+ */
+function encrypt_drush_command() {
+  $items = array();
+
+  $items['encrypt'] = array(
+    'description' => "Encrypt text with the provided encryption profile.",
+    'arguments' => array(
+      'profile' => 'The machine name of the encryption profile to use.',
+    ),
+    'options' => array(
+      'base64' => 'Output the encrypted text in base64 encoded format.',
+    ),
+    'examples' => array(
+      "drush encrypt profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile.',
+      "drush encrypt --base64 profile_name 'text to encrypt'" => 'Encrypts the given text with the specified encryption profile and base64-encodes output.',
+    ),
+    'callback' => 'drush_encrypt_encrypt',
+  );
+
+  $items['decrypt'] = array(
+    'description' => "Decrypt text with the provided encryption profile.",
+    'arguments' => array(
+      'profile' => 'The machine name of the encryption profile to use.',
+    ),
+    'options' => array(
+      'base64' => 'Output the encrypted text in base64 encoded format.',
+    ),
+    'examples' => array(
+      "drush decrypt profile_name 'text to decrypt'" => 'Decrypts the given text with the specified encryption profile.',
+      "drush decrypt --base64 profile_name 'text to decrypt'" => 'Decrypts the given base64-encoded text with the specified encryption profile.',
+    ),
+    'callback' => 'drush_encrypt_decrypt',
+  );
+
+  return $items;
+}
+
+/**
+ * Encrypt text with the given encryption profile.
+ *
+ * @param string $encryption_profile_name
+ *   The encryption profile machine name.
+ * @param string $text
+ *   The text to encrypt.
+ *
+ * @return string
+ *   The encrypted text.
+ */
+function drush_encrypt_encrypt($encryption_profile_name, $text) {
+  $service = \Drupal::service('encryption');
+  $encryption_profile = EncryptionProfile::load($encryption_profile_name);
+  if (!$encryption_profile) {
+    return drush_set_error('', dt('Encryption profile "@name" could not be loaded.', array(
+      '@name' => $encryption_profile_name,
+    )));
+  }
+  else {
+    $encrypted_text = $service->encrypt($text, $encryption_profile);
+    if (drush_get_option('base64')) {
+      $encrypted_text = base64_encode($encrypted_text);
+    }
+    drush_print($encrypted_text);
+  }
+}
+
+/**
+ * Decrypt text with the given encryption profile.
+ *
+ * @param string $encryption_profile_name
+ *   The encryption profile machine name.
+ * @param string $text
+ *   The text to decrypt.
+ *
+ * @return string
+ *   The decrypted text.
+ */
+function drush_encrypt_decrypt($encryption_profile_name, $text) {
+  $service = \Drupal::service('encryption');
+  $encryption_profile = EncryptionProfile::load($encryption_profile_name);
+  if (!$encryption_profile) {
+    return drush_set_error('', dt('Encryption profile "@name" could not be loaded.', array(
+      '@name' => $encryption_profile_name,
+    )));
+  }
+  else {
+    if (drush_get_option('base64')) {
+      $text = base64_decode($text);
+    }
+    $decrypted_text = $service->decrypt($text, $encryption_profile);
+    drush_print($decrypted_text);
+  }
+}

--- a/encrypt.routing.yml
+++ b/encrypt.routing.yml
@@ -30,6 +30,14 @@ entity.encryption_profile.delete_form:
   requirements:
     _permission: 'administer encrypt'
 
+entity.encryption_profile.test_form:
+  path: '/admin/config/system/encryption/profiles/manage/{encryption_profile}/test'
+  defaults:
+    _entity_form: 'encryption_profile.test'
+    _title: 'Test encryption profile'
+  requirements:
+    _permission: 'administer encrypt'
+
 encrypt.settings:
   path: '/admin/config/system/encryption/profiles/settings'
   defaults:

--- a/encrypt.services.yml
+++ b/encrypt.services.yml
@@ -8,3 +8,14 @@ services:
     parent: default_plugin_manager
     class: Drupal\encrypt\EncryptService
 
+  encrypt.encryption_profile.manager:
+    class: Drupal\encrypt\EncryptionProfileManager
+    arguments: ['@entity_type.manager']
+
+  encrypt.uninstall_validator:
+    class: Drupal\encrypt\EncryptUninstallValidator
+    tags:
+      - { name: module_install.uninstall_validator }
+    arguments: ['@string_translation', '@encryption', '@encrypt.encryption_profile.manager']
+    lazy: true
+

--- a/src/Controller/EncryptionProfileListBuilder.php
+++ b/src/Controller/EncryptionProfileListBuilder.php
@@ -106,4 +106,22 @@ class EncryptionProfileListBuilder extends ConfigEntityListBuilder {
     return $row + parent::buildRow($entity);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultOperations(EntityInterface $entity) {
+    /* @var \Drupal\Core\Config\Entity\ConfigEntityInterface $entity */
+    $operations = parent::getDefaultOperations($entity);
+
+    if ($entity->hasLinkTemplate('test-form')) {
+      $operations['test'] = array(
+        'title' => t('Test'),
+        'weight' => 30,
+        'url' => $entity->urlInfo('test-form'),
+      );
+    }
+
+    return $operations;
+  }
+
 }

--- a/src/EncryptService.php
+++ b/src/EncryptService.php
@@ -55,7 +55,7 @@ class EncryptService implements EncryptServiceInterface {
    * {@inheritdoc}
    */
   public function encrypt($text, EncryptionProfile $encryption_profile) {
-    if ($this->valid($text, $encryption_profile)) {
+    if ($this->validate($text, $encryption_profile)) {
       $key = $encryption_profile->getEncryptionKey();
       return $encryption_profile->getEncryptionMethod()->encrypt($text, $key->getKeyValue());
     }
@@ -65,7 +65,7 @@ class EncryptService implements EncryptServiceInterface {
    * {@inheritdoc}
    */
   public function decrypt($text, EncryptionProfile $encryption_profile) {
-    if ($this->valid($text, $encryption_profile)) {
+    if ($this->validate($text, $encryption_profile)) {
       $key = $encryption_profile->getEncryptionKey();
       return $encryption_profile->getEncryptionMethod()->decrypt($text, $key->getKeyValue());
     }
@@ -85,7 +85,7 @@ class EncryptService implements EncryptServiceInterface {
    * @throws \Drupal\encrypt\Exception\EncryptException
    *   Error with validation failures.
    */
-  protected function valid($text, EncryptionProfile $encryption_profile) {
+  protected function validate($text, EncryptionProfile $encryption_profile) {
     $errors = $encryption_profile->validate($text);
     if (!empty($errors)) {
       // Throw an exception with the errors from the encryption method.

--- a/src/EncryptUninstallValidator.php
+++ b/src/EncryptUninstallValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptUninstallValidator.
+ */
+
+namespace Drupal\encrypt;
+
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Prevents uninstallation of modules if an encryption method is still used.
+ */
+class EncryptUninstallValidator implements ModuleUninstallValidatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The encrypt service.
+   *
+   * @var \Drupal\encrypt\EncryptService
+   */
+  protected $encryptService;
+
+  /**
+   * The encryption profile manager.
+   *
+   * @var \Drupal\encrypt\EncryptionProfileManagerInterface
+   */
+  protected $encryptionProfileManager;
+
+  /**
+   * Constructs a new RoleAssignUninstallValidator.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\encrypt\EncryptServiceInterface $encrypt_service
+   *   The encryption service.
+   * @param \Drupal\encrypt\EncryptionProfileManagerInterface $encryption_profile_manager
+   *   The encryption profile manager.
+   */
+  public function __construct(TranslationInterface $string_translation, EncryptServiceInterface $encrypt_service, EncryptionProfileManagerInterface $encryption_profile_manager) {
+    $this->stringTranslation = $string_translation;
+    $this->encryptService = $encrypt_service;
+    $this->encryptionProfileManager = $encryption_profile_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    $reasons = [];
+    $encryption_method_plugins = [];
+    // Check if this module provides one or more EncryptionMethod plugins.
+    $definitions = $this->encryptService->loadEncryptionMethods();
+    foreach ($definitions as $definition) {
+      if ($definition['provider'] == $module) {
+        $encryption_method_plugins[] = $definition['id'];
+      }
+    }
+
+    // If the module provides EncryptionMethod plugins, check if they are used.
+    if (!empty($encryption_method_plugins)) {
+      foreach ($encryption_method_plugins as $plugin_id) {
+        if ($profiles = $this->encryptionProfileManager->getEncryptionProfilesByEncryptionMethod($plugin_id)) {
+          $used_in = [];
+          foreach ($profiles as $encryption_profile) {
+            $used_in[] = $encryption_profile->label();
+          }
+          $reasons[] = $this->t('Provides an encryption method that is in use in the following encryption profiles: %profiles', ['%profiles' => implode(', ', $used_in)]);
+        }
+      }
+    }
+
+    return $reasons;
+  }
+
+}

--- a/src/EncryptionProfileInterface.php
+++ b/src/EncryptionProfileInterface.php
@@ -65,9 +65,12 @@ interface EncryptionProfileInterface extends ConfigEntityInterface {
   /**
    * Validate the EncryptionProfile entity.
    *
+   * @param string $text
+   *   The text to be encrypted / decrypted.
+   *
    * @return array
    *   An array of validation errors. Empty if no errors.
    */
-  public function validate();
+  public function validate($text = NULL);
 
 }

--- a/src/EncryptionProfileManager.php
+++ b/src/EncryptionProfileManager.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptionProfileManager.
+ */
+
+namespace Drupal\encrypt;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Defines an EncryptionProfile manager.
+ */
+class EncryptionProfileManager implements EncryptionProfileManagerInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * Construct the EncryptionProfileManager object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   The entity manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager) {
+    $this->entityManager = $entity_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptionProfilesByEncryptionMethod($encryption_method_id) {
+    return $this->entityManager->getStorage('encryption_profile')->loadByProperties(array('encryption_method' => $encryption_method_id));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptionProfilesByEncryptionKey($key_id) {
+    return $this->entityManager->getStorage('encryption_profile')->loadByProperties(array('encryption_key' => $key_id));
+  }
+
+}

--- a/src/EncryptionProfileManagerInterface.php
+++ b/src/EncryptionProfileManagerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptionProfileManagerInterface.
+ */
+
+namespace Drupal\encrypt;
+
+/**
+ * Provides an interface defining an EncryptionProfile manager.
+ */
+interface EncryptionProfileManagerInterface {
+
+  /**
+   * Get EncryptionProfile entities by encryption method plugin ID.
+   *
+   * @param string $encryption_method_id
+   *   The plugin ID of the EncryptionMethod.
+   *
+   * @return \Drupal\encrypt\EncryptionProfileInterface[]
+   *   An array of EncryptionProfile entities.
+   */
+  public function getEncryptionProfilesByEncryptionMethod($encryption_method_id);
+
+  /**
+   * Get EncryptionProfile entities by encryption Key entity ID.
+   *
+   * @param string $key_id
+   *   The plugin ID of the EncryptionMethod.
+   *
+   * @return \Drupal\encrypt\EncryptionProfileInterface[]
+   *   An array of EncryptionProfile entities.
+   */
+  public function getEncryptionProfilesByEncryptionKey($key_id);
+
+}

--- a/src/Entity/EncryptionProfile.php
+++ b/src/Entity/EncryptionProfile.php
@@ -162,7 +162,7 @@ class EncryptionProfile extends ConfigEntityBase implements EncryptionProfileInt
   /**
    * {@inheritdoc}
    */
-  public function validate() {
+  public function validate($text = NULL) {
     $random = new Random();
     $errors = [];
 
@@ -201,7 +201,10 @@ class EncryptionProfile extends ConfigEntityBase implements EncryptionProfileInt
         }
         // Check if encryption method dependencies are met.
         $encryption_method = $this->getEncryptionMethod();
-        $dependency_errors = $encryption_method->checkDependencies($random->string(), $selected_key->getKeyValue());
+        if (!$text) {
+          $text = $random->string();
+        }
+        $dependency_errors = $encryption_method->checkDependencies($text, $selected_key->getKeyValue());
         $errors = array_merge($errors, $dependency_errors);
       }
     }

--- a/src/Entity/EncryptionProfile.php
+++ b/src/Entity/EncryptionProfile.php
@@ -28,6 +28,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  *       "add" = "Drupal\encrypt\Form\EncryptionProfileForm",
  *       "edit" = "Drupal\encrypt\Form\EncryptionProfileForm",
  *       "delete" = "Drupal\encrypt\Form\EncryptionProfileDeleteForm",
+ *       "test" = "Drupal\encrypt\Form\EncryptionProfileTestForm",
  *       "default" = "Drupal\encrypt\Form\EncryptionProfileDefaultForm"
  *     }
  *   },
@@ -43,6 +44,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  *     "add-form" = "/admin/config/system/encryption/profiles/add",
  *     "edit-form" = "/admin/config/system/encryption/profiles/manage/{encryption_profile}",
  *     "delete-form" = "/admin/config/system/encryption/profiles/manage/{encryption_profile}/delete",
+ *     "test-form" = "/admin/config/system/encryption/profiles/manage/{encryption_profile}/test",
  *     "collection" = "/admin/config/system/encryption/profiles"
  *   },
  *   config_export = {

--- a/src/Form/EncryptionProfileTestForm.php
+++ b/src/Form/EncryptionProfileTestForm.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\Form\EncryptionProfileTestForm.
+ */
+
+namespace Drupal\encrypt\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\encrypt\EncryptService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EncryptionProfileTestForm.
+ */
+class EncryptionProfileTestForm extends EntityForm {
+
+  /**
+   * The encrypt service.
+   *
+   * @var \Drupal\encrypt\EncryptService
+   */
+  protected $encryptService;
+
+  /**
+   * Constructs the test form.
+   *
+   * @param \Drupal\encrypt\EncryptService $encrypt_service
+   *   The encryption service.
+   */
+  public function __construct(EncryptService $encrypt_service) {
+    $this->encryptService = $encrypt_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('encryption')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+
+    $form['encrypt'] = array(
+      '#type' => 'details',
+      '#title' => t('Encryption test'),
+      '#open' => TRUE,
+    );
+
+    $form['encrypt']['to_encrypt'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Text to encrypt'),
+      '#description' => $this->t('Specify the text you want to encrypt with this encryption profile. The result of the encryption will be shown below.'),
+    );
+
+    $form['encrypt']['encrypt_base64'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Base64-encode the encrypted text.'),
+    );
+
+    $form['encrypt']['encrypt_text'] = array(
+      '#type' => 'submit',
+      '#value' => $this->t('Encrypt'),
+      '#name' => 'encrypt',
+    );
+
+    $form['encrypt']['encrypted'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Encrypted text'),
+      '#value' => $form_state->getValue('encrypted'),
+      '#disabled' => TRUE,
+    );
+
+    $form['decrypt'] = array(
+      '#type' => 'details',
+      '#title' => t('Decryption test'),
+      '#open' => TRUE,
+    );
+
+    $form['decrypt']['to_decrypt'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Text to decrypt'),
+      '#description' => $this->t('Specify the text you want to decrypt with this encryption profile. The result of the decryption will be shown below.'),
+    );
+
+    $form['decrypt']['decrypt_base64'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Base64-decode the encrypted text before decrypting.'),
+    );
+
+    $form['decrypt']['decrypt_text'] = array(
+      '#type' => 'submit',
+      '#value' => $this->t('Decrypt'),
+      '#name' => 'decrypt',
+    );
+
+    $form['decrypt']['decrypted'] = array(
+      '#type' => 'textarea',
+      '#title' => $this->t('Decrypted text'),
+      '#value' => $form_state->getValue('decrypted'),
+      '#disabled' => TRUE,
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $trigger = $form_state->getTriggeringElement();
+    switch ($trigger['#name']) {
+      case 'encrypt':
+        if ($to_encrypt = $form_state->getValue('to_encrypt')) {
+          $encrypted_text = $this->encryptService->encrypt($to_encrypt, $this->entity);
+          if ($form_state->getValue('encrypt_base64')) {
+            $encrypted_text = base64_encode($encrypted_text);
+          }
+          $form_state->setValue('encrypted', $encrypted_text);
+        }
+        break;
+
+      case 'decrypt':
+        if ($to_decrypt = $form_state->getValue('to_decrypt')) {
+          if ($form_state->getValue('decrypt_base64')) {
+            $to_decrypt = base64_decode($to_decrypt);
+          }
+          $decrypted_text = $this->encryptService->decrypt($to_decrypt, $this->entity);
+          $form_state->setValue('decrypted', $decrypted_text);
+        }
+        break;
+    }
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $actions = parent::actions($form, $form_state);
+    unset($actions['submit']);
+    unset($actions['delete']);
+    return $actions;
+  }
+
+}

--- a/src/ProxyClass/EncryptUninstallValidator.php
+++ b/src/ProxyClass/EncryptUninstallValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\ProxyClass\EncryptUninstallValidator.
+ */
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\encrypt\EncryptUninstallValidator' "modules/encrypt/src".
+ */
+
+namespace Drupal\encrypt\ProxyClass {
+
+  /**
+   * Provides a proxy class for \Drupal\encrypt\EncryptUninstallValidator.
+   *
+   * @see \Drupal\Component\ProxyBuilder
+   */
+  class EncryptUninstallValidator implements \Drupal\Core\Extension\ModuleUninstallValidatorInterface {
+
+    use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+    /**
+     * The id of the original proxied service.
+     *
+     * @var string
+     */
+    protected $drupalProxyOriginalServiceId;
+
+    /**
+     * The real proxied service, after it was lazy loaded.
+     *
+     * @var \Drupal\encrypt\EncryptUninstallValidator
+     */
+    protected $service;
+
+    /**
+     * The service container.
+     *
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Constructs a ProxyClass Drupal proxy object.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     *   The container.
+     * @param string $drupal_proxy_original_service_id
+     *   The service ID of the original service.
+     */
+    public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id) {
+
+      $this->container = $container;
+      $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+    }
+
+    /**
+     * Lazy loads the real service from the container.
+     *
+     * @return object
+     *   Returns the constructed real service.
+     */
+    protected function lazyLoadItself() {
+
+      if (!isset($this->service)) {
+        $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+      }
+
+      return $this->service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($module) {
+
+      return $this->lazyLoadItself()->validate($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStringTranslation(\Drupal\Core\StringTranslation\TranslationInterface $translation) {
+
+      return $this->lazyLoadItself()->setStringTranslation($translation);
+    }
+
+  }
+
+}

--- a/src/Tests/EncryptTest.php
+++ b/src/Tests/EncryptTest.php
@@ -42,7 +42,7 @@ class EncryptTest extends WebTestBase {
 
 
   /**
-   * A list of testkeys
+   * A list of testkeys.
    *
    * @var \Drupal\key\Entity\Key[]
    */

--- a/tests/src/Unit/EncryptServiceTest.php
+++ b/tests/src/Unit/EncryptServiceTest.php
@@ -120,7 +120,7 @@ class EncryptServiceTest extends UnitTestCase {
    * @covers ::__construct
    * @covers ::encrypt
    * @covers ::decrypt
-   * @covers ::valid
+   * @covers ::validate
    *
    * @dataProvider encryptionDataProvider
    */

--- a/tests/src/Unit/EncryptServiceTest.php
+++ b/tests/src/Unit/EncryptServiceTest.php
@@ -49,6 +49,13 @@ class EncryptServiceTest extends UnitTestCase {
   protected $encryptionMethod;
 
   /**
+   * A mocked Key entity.
+   *
+   * @var \Drupal\key\Entity\Key|\PHPUnit_Framework_MockObject_MockObject
+   */
+  protected $key;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
@@ -71,6 +78,11 @@ class EncryptServiceTest extends UnitTestCase {
 
     // Set up a mock EncryptionMethod plugin.
     $this->encryptionMethod = $this->getMockBuilder('\Drupal\encrypt\EncryptionMethodInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    // Set up a mock Key entity.
+    $this->key = $this->getMockBuilder('\Drupal\key\Entity\Key')
       ->disableOriginalConstructor()
       ->getMock();
   }
@@ -103,146 +115,75 @@ class EncryptServiceTest extends UnitTestCase {
   }
 
   /**
-   * Tests the encrypt method.
+   * Tests the encrypt & decrypt method.
    *
    * @covers ::__construct
    * @covers ::encrypt
-   */
-  public function testEncrypt() {
-    // Set up a mock for the EncryptService class to mock some methods.
-    $encrypt_service = $this->getMockBuilder('\Drupal\encrypt\EncryptService')
-      ->setMethods([
-        'getEncryptionKeyValue',
-        'getEncryptionMethod',
-      ])
-      ->setConstructorArgs(array(
-        $this->encryptManager,
-        $this->keyRepository,
-      ))
-      ->getMock();
-
-    // Set up expectations for encryption method.
-    $this->encryptionMethod->expects($this->once())
-      ->method('encrypt')
-      ->will($this->returnValue("encrypted_text"));
-
-    $encrypt_service->expects($this->once())
-      ->method('getEncryptionKeyValue')
-      ->will($this->returnValue('encryption_key'));
-
-    $encrypt_service->expects($this->any())
-      ->method('getEncryptionMethod')
-      ->will($this->returnValue($this->encryptionMethod));
-
-    $encrypted_text = $encrypt_service->encrypt("text_to_encrypt", $this->encryptionProfile);
-    $this->assertEquals("encrypted_text", $encrypted_text);
-  }
-
-  /**
-   * Tests the decrypt method.
-   *
-   * @covers ::__construct
    * @covers ::decrypt
-   */
-  public function testDecrypt() {
-    // Set up a mock for the EncryptService class to mock some methods.
-    $encrypt_service = $this->getMockBuilder('\Drupal\encrypt\EncryptService')
-      ->setMethods([
-        'getEncryptionKeyValue',
-        'getEncryptionMethod',
-      ]
-      )
-      ->setConstructorArgs(array(
-        $this->encryptManager,
-        $this->keyRepository,
-      ))
-      ->getMock();
-
-    // Set up expectations for encryption method.
-    $this->encryptionMethod->expects($this->once())
-      ->method('decrypt')
-      ->will($this->returnValue("decrypted_text"));
-
-    $encrypt_service->expects($this->once())
-      ->method('getEncryptionKeyValue')
-      ->will($this->returnValue('encryption_key'));
-
-    $encrypt_service->expects($this->any())
-      ->method('getEncryptionMethod')
-      ->will($this->returnValue($this->encryptionMethod));
-
-    $encrypted_text = $encrypt_service->decrypt("text_to_encrypt", $this->encryptionProfile);
-    $this->assertEquals("decrypted_text", $encrypted_text);
-  }
-
-  /**
-   * Tests the getEncryptionKeyValue() method.
+   * @covers ::valid
    *
-   * @covers ::getEncryptionKeyValue
-   *
-   * @dataProvider encryptionKeyValueDataProvider
+   * @dataProvider encryptionDataProvider
    */
-  public function testGetEncryptionKeyValue($key, $valid_key) {
-    // Set up a mock for the EncryptService class to mock some methods.
-    $encrypt_service = $this->getMockBuilder('\Drupal\encrypt\EncryptService')
-      ->setMethods(['loadEncryptionProfileKey']
-      )
-      ->setConstructorArgs(array(
-        $this->encryptManager,
-        $this->keyRepository,
-      ))
-      ->getMock();
+  public function testEncryptDecrypt($key, $valid_key) {
+    // Set up expectations for Key.
+    $this->key->expects($this->any())
+      ->method('getKeyValue')
+      ->will($this->returnValue($key));
 
-    // Set up expectations for encryption method.
     if ($valid_key) {
+      // Set up expectations for encryption method.
       $this->encryptionMethod->expects($this->once())
         ->method('encrypt')
         ->will($this->returnValue("encrypted_text"));
       $this->encryptionMethod->expects($this->once())
-        ->method('checkDependencies')
-        ->will($this->returnValue(array()));
-      $encrypt_service->expects($this->any())
+        ->method('decrypt')
+        ->will($this->returnValue("decrypted_text"));
+
+      // Set up expectations for encryption profile.
+      $this->encryptionProfile->expects($this->any())
+        ->method('getEncryptionKey')
+        ->will($this->returnValue($this->key));
+      $this->encryptionProfile->expects($this->any())
         ->method('getEncryptionMethod')
         ->will($this->returnValue($this->encryptionMethod));
+      $this->encryptionProfile->expects($this->any())
+        ->method('validate')
+        ->will($this->returnValue(array()));
     }
     else {
-      $this->encryptionMethod->expects($this->never())
-        ->method('encrypt');
-      $this->encryptionMethod->expects($this->once())
-        ->method('checkDependencies')
-        ->will($this->returnValue(array("Dependency error")));
-      $this->setExpectedException('\Drupal\encrypt\Exception\EncryptException');
-      $encrypt_service->expects($this->never())
+      // Set up expectations for encryption profile.
+      $this->encryptionProfile->expects($this->never())
+        ->method('getEncryptionKey');
+      $this->encryptionProfile->expects($this->never())
         ->method('getEncryptionMethod');
+      $this->encryptionProfile->expects($this->any())
+        ->method('validate')
+        ->will($this->returnValue(array("Validation error")));
+      $this->setExpectedException('\Drupal\encrypt\Exception\EncryptException');
     }
 
-    // Set up expectations for encryption profile.
-    $this->encryptionProfile->expects($this->any())
-      ->method('getEncryptionMethod')
-      ->will($this->returnValue($this->encryptionMethod));
+    $service = new EncryptService(
+      $this->encryptManager,
+      $this->keyRepository
+    );
 
-    $encrypt_service->expects($this->once())
-      ->method('loadEncryptionProfileKey')
-      ->with($this->encryptionProfile)
-      ->will($this->returnValue($key));
-
-    // Call getEncryptionKeyValue() through the public encrypt() method.
-    $encrypted_text = $encrypt_service->encrypt("text_to_encrypt", $this->encryptionProfile);
+    $encrypted_text = $service->encrypt("text_to_encrypt", $this->encryptionProfile);
+    $decrypted_text = $service->decrypt("text_to_decrypt", $this->encryptionProfile);
     if ($valid_key) {
       $this->assertEquals("encrypted_text", $encrypted_text);
+      $this->assertEquals("decrypted_text", $decrypted_text);
     }
-
   }
 
   /**
-   * Data provider for testGetEncryptionKeyValue method.
+   * Data provider for encrypt / decrypt method.
    *
    * @return array
-   *   An array with data for the testGetEncryptionKeyValue method.
+   *   An array with data for the test method.
    */
-  public function encryptionKeyValueDataProvider() {
+  public function encryptionDataProvider() {
     return [
-      'normal' => ["mustbesixteenbit", TRUE],
+      'normal' => ["validkey", TRUE],
       'exception' => ["invalidkey", FALSE],
     ];
   }


### PR DESCRIPTION
The current implementation of EncryptService only calls checkDependencies() on the selected encryption method, before trying to encrypt.

This PR simplifies the code & test logic of the EncryptService, and makes sure the validate() function on the EncryptionProfile entity gets called. This will still call checkDependencies(), but also provide extra validation (e.g.: check if encryption key is still available).