### PR TITLE
Provide uninstall validation checks

### DIFF
--- a/encrypt.services.yml
+++ b/encrypt.services.yml
@@ -8,3 +8,14 @@ services:
     parent: default_plugin_manager
     class: Drupal\encrypt\EncryptService
 
+  encrypt.encryption_profile.manager:
+    class: Drupal\encrypt\EncryptionProfileManager
+    arguments: ['@entity_type.manager']
+
+  encrypt.uninstall_validator:
+    class: Drupal\encrypt\EncryptUninstallValidator
+    tags:
+      - { name: module_install.uninstall_validator }
+    arguments: ['@string_translation', '@encryption', '@encrypt.encryption_profile.manager']
+    lazy: true
+

--- a/src/EncryptUninstallValidator.php
+++ b/src/EncryptUninstallValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptUninstallValidator.
+ */
+
+namespace Drupal\encrypt;
+
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Prevents uninstallation of modules if an encryption method is still used.
+ */
+class EncryptUninstallValidator implements ModuleUninstallValidatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The encrypt service.
+   *
+   * @var \Drupal\encrypt\EncryptService
+   */
+  protected $encryptService;
+
+  /**
+   * The encryption profile manager.
+   *
+   * @var \Drupal\encrypt\EncryptionProfileManagerInterface
+   */
+  protected $encryptionProfileManager;
+
+  /**
+   * Constructs a new RoleAssignUninstallValidator.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\encrypt\EncryptServiceInterface $encrypt_service
+   *   The encryption service.
+   * @param \Drupal\encrypt\EncryptionProfileManagerInterface $encryption_profile_manager
+   *   The encryption profile manager.
+   */
+  public function __construct(TranslationInterface $string_translation, EncryptServiceInterface $encrypt_service, EncryptionProfileManagerInterface $encryption_profile_manager) {
+    $this->stringTranslation = $string_translation;
+    $this->encryptService = $encrypt_service;
+    $this->encryptionProfileManager = $encryption_profile_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    $reasons = [];
+    $encryption_method_plugins = [];
+    // Check if this module provides one or more EncryptionMethod plugins.
+    $definitions = $this->encryptService->loadEncryptionMethods();
+    foreach ($definitions as $definition) {
+      if ($definition['provider'] == $module) {
+        $encryption_method_plugins[] = $definition['id'];
+      }
+    }
+
+    // If the module provides EncryptionMethod plugins, check if they are used.
+    if (!empty($encryption_method_plugins)) {
+      foreach ($encryption_method_plugins as $plugin_id) {
+        if ($profiles = $this->encryptionProfileManager->getEncryptionProfilesByEncryptionMethod($plugin_id)) {
+          $used_in = [];
+          foreach ($profiles as $encryption_profile) {
+            $used_in[] = $encryption_profile->label();
+          }
+          $reasons[] = $this->t('Provides an encryption method that is in use in the following encryption profiles: %profiles', ['%profiles' => implode(', ', $used_in)]);
+        }
+      }
+    }
+
+    return $reasons;
+  }
+
+}

--- a/src/EncryptionProfileManager.php
+++ b/src/EncryptionProfileManager.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptionProfileManager.
+ */
+
+namespace Drupal\encrypt;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Defines an EncryptionProfile manager.
+ */
+class EncryptionProfileManager implements EncryptionProfileManagerInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * Construct the EncryptionProfileManager object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   The entity manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager) {
+    $this->entityManager = $entity_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptionProfilesByEncryptionMethod($encryption_method_id) {
+    return $this->entityManager->getStorage('encryption_profile')->loadByProperties(array('encryption_method' => $encryption_method_id));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEncryptionProfilesByEncryptionKey($key_id) {
+    return $this->entityManager->getStorage('encryption_profile')->loadByProperties(array('encryption_key' => $key_id));
+  }
+
+}

--- a/src/EncryptionProfileManagerInterface.php
+++ b/src/EncryptionProfileManagerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\EncryptionProfileManagerInterface.
+ */
+
+namespace Drupal\encrypt;
+
+/**
+ * Provides an interface defining an EncryptionProfile manager.
+ */
+interface EncryptionProfileManagerInterface {
+
+  /**
+   * Get EncryptionProfile entities by encryption method plugin ID.
+   *
+   * @param string $encryption_method_id
+   *   The plugin ID of the EncryptionMethod.
+   *
+   * @return \Drupal\encrypt\EncryptionProfileInterface[]
+   *   An array of EncryptionProfile entities.
+   */
+  public function getEncryptionProfilesByEncryptionMethod($encryption_method_id);
+
+  /**
+   * Get EncryptionProfile entities by encryption Key entity ID.
+   *
+   * @param string $key_id
+   *   The plugin ID of the EncryptionMethod.
+   *
+   * @return \Drupal\encrypt\EncryptionProfileInterface[]
+   *   An array of EncryptionProfile entities.
+   */
+  public function getEncryptionProfilesByEncryptionKey($key_id);
+
+}

--- a/src/ProxyClass/EncryptUninstallValidator.php
+++ b/src/ProxyClass/EncryptUninstallValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\encrypt\ProxyClass\EncryptUninstallValidator.
+ */
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\encrypt\EncryptUninstallValidator' "modules/encrypt/src".
+ */
+
+namespace Drupal\encrypt\ProxyClass {
+
+  /**
+   * Provides a proxy class for \Drupal\encrypt\EncryptUninstallValidator.
+   *
+   * @see \Drupal\Component\ProxyBuilder
+   */
+  class EncryptUninstallValidator implements \Drupal\Core\Extension\ModuleUninstallValidatorInterface {
+
+    use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+    /**
+     * The id of the original proxied service.
+     *
+     * @var string
+     */
+    protected $drupalProxyOriginalServiceId;
+
+    /**
+     * The real proxied service, after it was lazy loaded.
+     *
+     * @var \Drupal\encrypt\EncryptUninstallValidator
+     */
+    protected $service;
+
+    /**
+     * The service container.
+     *
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Constructs a ProxyClass Drupal proxy object.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     *   The container.
+     * @param string $drupal_proxy_original_service_id
+     *   The service ID of the original service.
+     */
+    public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id) {
+
+      $this->container = $container;
+      $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+    }
+
+    /**
+     * Lazy loads the real service from the container.
+     *
+     * @return object
+     *   Returns the constructed real service.
+     */
+    protected function lazyLoadItself() {
+
+      if (!isset($this->service)) {
+        $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+      }
+
+      return $this->service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($module) {
+
+      return $this->lazyLoadItself()->validate($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStringTranslation(\Drupal\Core\StringTranslation\TranslationInterface $translation) {
+
+      return $this->lazyLoadItself()->setStringTranslation($translation);
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR adds an uninstall validator service.

When trying to uninstall any module, it checks whether that module provides an EncryptionMethod plugin definition. If so, it checks if any EncryptionProfile entity is currently making use of that EncryptionMethod. If so, the uninstall is prevented, with an explanation stating which profile is still using it.

This PR also adds the EncryptionProfileManager to provide a consistent way of loading EncryptionProfile entities based on a given property.

These changes will avoid disabling encryption methods by accident, thus rendering the encryption profiles using them useless. 