### PR TITLE
Add best practices + clean up code

### DIFF
--- a/drush/encrypt.drush.inc
+++ b/drush/encrypt.drush.inc
@@ -6,18 +6,19 @@
  */
 
 use Drupal\encrypt\Entity\EncryptionProfile;
-use Drush\Log\Logger;
 use Drush\Log\LogLevel;
 
 /**
- * Implementation of hook_drush_help().
+ * Implements hook_drush_help().
  */
 function encrypt_drush_help($section) {
   switch ($section) {
     case 'meta:encrypt:title':
       return dt('Encrypt commands');
+
     case 'meta:encrypt:summary':
       return dt('Interact with the encryption service.');
+
   }
 }
 
@@ -137,7 +138,11 @@ function drush_encrypt_decrypt($encryption_profile_name, $text) {
 /**
  * Validates the given encryption profile.
  *
- * @param $encryption_profile_name
+ * @param string $encryption_profile_name
+ *   The ID of the encryption profile to validate.
+ *
+ * @return array
+ *   An error of validation errors for the given encryption profile.
  */
 function drush_encrypt_validate_profile($encryption_profile_name) {
   $output = array();

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,34 @@ The service is configured through the settings form, found at
 It requires a key, which is provided by the Key module. To manage keys, visit 
 `admin/config/system/key`.
 
+## Best practices
+
+In order to provide real security, it is highly recommended to follow these 
+best practices:
+
+### Encryption method
+
+Use a high-quality, modern security library for encrypting your data.
+The Real AES module (https://www.drupal.org/project/real_aes) provides 
+integration with the recommended Defuse PHP Encryption library.
+
+Read the README.txt document provided by the Real AES module for detailed 
+security information and best practices, as well as further background 
+information.
+
+### Key
+
+Be sure to use a key value with an appropriately secure size (at least 128 bits)
+and decent quality (i.e. proper randomness).
+
+Make sure to store your keys in an appropriately secure place. Keep your keys
+out of the database, out of the web root and on a different server, if possible.
+
+The "Configuration" key provider (as defined by the Key module) should only be
+used for testing purposes. Never use this key provider in a production 
+environment, or any environment where security is required. 
+
+
 ## Use of Services
 
 After configuring the service, the service provides the ability to encrypt and 
@@ -42,7 +70,8 @@ If you don't want to use the "use" statement in the examples above, you can
 use the following code to retrieve the encryption profile:
 
 ```
-$encryption_profile = \Drupal::service('entity.manager')->getStorage('encryption_profile')->load($instance_id);
+$encryption_profile = \Drupal::service('entity.manager')
+  ->getStorage('encryption_profile')->load($instance_id);
 ```
 
 ## Writing your own EncryptionMethod plugin

--- a/src/EncryptService.php
+++ b/src/EncryptService.php
@@ -74,7 +74,7 @@ class EncryptService implements EncryptServiceInterface {
   /**
    * Determines whether the input is valid for encryption / decryption.
    *
-   * @param $text
+   * @param string $text
    *   The text to encrypt / decrypt.
    * @param \Drupal\encrypt\Entity\EncryptionProfile $encryption_profile
    *   The encryption profile to validate.

--- a/src/Form/EncryptionProfileDeleteForm.php
+++ b/src/Form/EncryptionProfileDeleteForm.php
@@ -46,7 +46,7 @@ class EncryptionProfileDeleteForm extends EntityConfirmFormBase {
       $this->t('content @type: deleted @label.',
         [
           '@type' => $this->entity->bundle(),
-          '@label' => $this->entity->label()
+          '@label' => $this->entity->label(),
         ]
         )
     );

--- a/src/Form/EncryptionProfileForm.php
+++ b/src/Form/EncryptionProfileForm.php
@@ -15,7 +15,7 @@ use Drupal\encrypt\Plugin\EncryptionMethodPluginFormInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class EncryptionProfileForm.
+ * Provides the form to add / edit an EncryptionProfile entity.
  *
  * @package Drupal\encrypt\Form
  */
@@ -230,6 +230,9 @@ class EncryptionProfileForm extends EntityForm {
 
   /**
    * Update the EncryptionMethod plugin.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
    */
   protected function updateEncryptionMethod(FormStateInterface $form_state) {
     /* @var $encryption_profile \Drupal\encrypt\Entity\EncryptionProfile */
@@ -266,6 +269,7 @@ class EncryptionProfileForm extends EntityForm {
       return;
     }
 
+    // If the encryption method contains a config form, validate it as well.
     if ($plugin = $this->entity->getEncryptionMethod()) {
       if ($plugin instanceof EncryptionMethodPluginFormInterface) {
         $plugin_form_state = $this->createPluginFormState($form_state);
@@ -290,6 +294,7 @@ class EncryptionProfileForm extends EntityForm {
     /** @var \Drupal\encrypt\Entity\EncryptionConfiguration $entity */
     $this->entity = $this->buildEntity($form, $form_state);
 
+    // Validate the EncryptionProfile entity.
     $errors = $this->entity->validate();
     if ($errors) {
       $form_state->setErrorByName('encryption_key', implode(';', $errors));

--- a/src/Form/EncryptionProfileForm.php
+++ b/src/Form/EncryptionProfileForm.php
@@ -40,7 +40,7 @@ class EncryptionProfileForm extends EntityForm {
    *
    * @var bool
    */
-  protected $edit_confirmed = FALSE;
+  protected $editConfirmed = FALSE;
 
   /**
    * The original encryption profile.
@@ -106,7 +106,7 @@ class EncryptionProfileForm extends EntityForm {
     $encryption_profile = $this->entity;
 
     $disabled = FALSE;
-    if ($this->operation == "edit" && !$this->edit_confirmed) {
+    if ($this->operation == "edit" && !$this->editConfirmed) {
       $disabled = TRUE;
     }
 
@@ -278,10 +278,10 @@ class EncryptionProfileForm extends EntityForm {
 
     // Check if we can enable full profile editing,
     // after explicit user confirmation.
-    if ($this->operation == "edit" && $this->edit_confirmed != TRUE) {
+    if ($this->operation == "edit" && $this->editConfirmed != TRUE) {
       $form_state->setRebuild();
       if ($form_state->getValue('confirm_edit') == TRUE) {
-        $this->edit_confirmed = TRUE;
+        $this->editConfirmed = TRUE;
         return;
       }
     }

--- a/src/Form/EncryptionProfileTestForm.php
+++ b/src/Form/EncryptionProfileTestForm.php
@@ -13,7 +13,7 @@ use Drupal\encrypt\EncryptService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class EncryptionProfileTestForm.
+ * Provides a form for testing encryption / decryption on a given profile.
  */
 class EncryptionProfileTestForm extends EntityForm {
 

--- a/src/Tests/EncryptTest.php
+++ b/src/Tests/EncryptTest.php
@@ -17,16 +17,6 @@ use Drupal\simpletest\WebTestBase;
 class EncryptTest extends WebTestBase {
 
   /**
-   * Exempt from strict schema checking.
-   *
-   * @see \Drupal\Core\Config\Testing\ConfigSchemaChecker
-   *
-   * @var bool
-   */
-  // @TODO: remove if https://www.drupal.org/node/2666196 is fixed.
-  protected $strictConfigSchema = FALSE;
-
-  /**
    * Modules to enable for this test.
    *
    * @var string[]


### PR DESCRIPTION
This PR adds security recommendations to the readme.md, as laid out in https://github.com/d8-contrib-modules/encrypt/issues/79.

In the best practices I refer to the README.txt file of the real_aes module, which contains elaborate information and security best practices.

The recommendations in this PR can probably still be expanded with more information and warnings where necessary, but I think this is a good first step to have included in our first alpha release.

Feel free to append with any other recommendations that should be included.

This PR also does some code cleanup according to the Drupal coding standards.
